### PR TITLE
flake.nix: URL literals are deprecated

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
-      url = github:edolstra/flake-compat;
+      url = "github:edolstra/flake-compat";
       flake = false;
     };
   };


### PR DESCRIPTION
URL literals are deprecated on Lix, causing any transitive use of that Flake, an error at evaluation time.